### PR TITLE
Update current ScoreTypes to handle (x, y, r, conf)

### DIFF
--- a/problem.py
+++ b/problem.py
@@ -21,8 +21,10 @@ workflow = local_workflow.workflow.ObjectDetector(
 
 score_types = [
     local_workflow.scores.Ospa(),
-    # local_scores.Accuracy(name='acc'),
-    # local_scores.NegativeLogLikelihood(name='nll'),
+    local_workflow.scores.Precision(),
+    local_workflow.scores.Recall(),
+    local_workflow.scores.MAD_Center(),
+    local_workflow.scores.MAD_Radius(),
 ]
 
 

--- a/submissions/image_processing/object_detector_model.py
+++ b/submissions/image_processing/object_detector_model.py
@@ -23,7 +23,7 @@ class ObjectDetector:
         hough_radii = list(np.arange(5, 20, 1)) + list(np.arange(20, 50, 2))
 
         circles = hough_circle(edges, hough_radii)
-        print('Max val: ', np.max(circles))
+        # print('Max val: ', np.max(circles))
         peaks = hough_circle_peaks(circles, hough_radii,
                                    threshold=self.threshold)
         return edges, peaks
@@ -34,7 +34,7 @@ class ObjectDetector:
     def _predict_single(self, X):
         edges, peaks = self._hough_detection(X)
         accum, cx, cy, radii = peaks
-        return list(zip(cx, cy, radii))
+        return list(zip(cx, cy, radii, accum))
 
     def show_prediction(self, X):
         import matplotlib.pyplot as plt

--- a/workflow/scores/mask.py
+++ b/workflow/scores/mask.py
@@ -44,11 +44,17 @@ class MaskDetection(BaseScoreType):
     minimum = 0.0
     maximum = np.inf
 
-    def __init__(self, name='mask_detection', precision=2):
+    def __init__(self, name='mask_detection', precision=2, conf_threshold=0.5):
         self.name = name
         self.precision = precision
+        self.conf_threshold = conf_threshold
 
-    def __call__(self, y_true, y_pred):
-        scores = [mask_detection(t, p) for t, p in zip(y_true, y_pred)]
+    def __call__(self, y_true, y_pred, conf_threshold=None):
+        if conf_threshold is None:
+            conf_threshold = self.conf_threshold
+        y_pred_temp = [
+            [(x, y, r) for (x, y, r, p) in y_pred_patch if p > conf_threshold]
+            for y_pred_patch in y_pred]
+        scores = [mask_detection(t, p) for t, p in zip(y_true, y_pred_temp)]
         true_craters = [len(t) for t in y_true]
         return np.sum(scores) / np.sum(true_craters)

--- a/workflow/scores/ospa.py
+++ b/workflow/scores/ospa.py
@@ -109,11 +109,18 @@ class Ospa(BaseScoreType):
     minimum = 0.0
     maximum = 1.0
 
-    def __init__(self, name='OSPA', precision=2):
+    def __init__(self, name='OSPA', precision=2, conf_threshold=0.5):
         self.name = name
         self.precision = precision
+        self.conf_threshold = conf_threshold
 
-    def __call__(self, y_true, y_pred):
-        scores = [score_craters_on_patch(t, p) for t, p in zip(y_true, y_pred)]
+    def __call__(self, y_true, y_pred, conf_threshold=None):
+        if conf_threshold is None:
+            conf_threshold = self.conf_threshold
+        y_pred_temp = [
+            [(x, y, r) for (x, y, r, p) in y_pred_patch if p > conf_threshold]
+            for y_pred_patch in y_pred]
+        scores = [score_craters_on_patch(t, p) for t, p in zip(y_true,
+                                                               y_pred_temp)]
         weights = [len(t) for t in y_true]
         return np.average(scores, weights=weights)

--- a/workflow/scores/precision_recall.py
+++ b/workflow/scores/precision_recall.py
@@ -220,12 +220,18 @@ class Precision(BaseScoreType):
     minimum = 0.0
     maximum = 1.0
 
-    def __init__(self, name='precision', precision=2):
+    def __init__(self, name='precision', precision=2, conf_threshold=0.5):
         self.name = name
         self.precision = precision
+        self.conf_threshold = conf_threshold
 
-    def __call__(self, y_true, y_pred):
-        return precision(y_true, y_pred)
+    def __call__(self, y_true, y_pred, conf_threshold=None):
+        if conf_threshold is None:
+            conf_threshold = self.conf_threshold
+        y_pred_temp = [
+            [(x, y, r) for (x, y, r, p) in y_pred_patch if p > conf_threshold]
+            for y_pred_patch in y_pred]
+        return precision(y_true, y_pred_temp)
 
 
 class Recall(BaseScoreType):
@@ -233,12 +239,18 @@ class Recall(BaseScoreType):
     minimum = 0.0
     maximum = 1.0
 
-    def __init__(self, name='recall', precision=2):
+    def __init__(self, name='recall', precision=2, conf_threshold=0.5):
         self.name = name
         self.precision = precision
+        self.conf_threshold = conf_threshold
 
-    def __call__(self, y_true, y_pred):
-        return recall(y_true, y_pred)
+    def __call__(self, y_true, y_pred, conf_threshold=None):
+        if conf_threshold is None:
+            conf_threshold = self.conf_threshold
+        y_pred_temp = [
+            [(x, y, r) for (x, y, r, p) in y_pred_patch if p > conf_threshold]
+            for y_pred_patch in y_pred]
+        return recall(y_true, y_pred_temp)
 
 
 class MAD_Center(BaseScoreType):
@@ -246,12 +258,18 @@ class MAD_Center(BaseScoreType):
     minimum = 0.0
     maximum = np.inf
 
-    def __init__(self, name='mad_center', precision=2):
+    def __init__(self, name='mad_center', precision=2, conf_threshold=0.5):
         self.name = name
         self.precision = precision
+        self.conf_threshold = conf_threshold
 
-    def __call__(self, y_true, y_pred):
-        return mad_center(y_true, y_pred)
+    def __call__(self, y_true, y_pred, conf_threshold=None):
+        if conf_threshold is None:
+            conf_threshold = self.conf_threshold
+        y_pred_temp = [
+            [(x, y, r) for (x, y, r, p) in y_pred_patch if p > conf_threshold]
+            for y_pred_patch in y_pred]
+        return mad_center(y_true, y_pred_temp)
 
 
 class MAD_Radius(BaseScoreType):
@@ -259,9 +277,15 @@ class MAD_Radius(BaseScoreType):
     minimum = 0.0
     maximum = np.inf
 
-    def __init__(self, name='mad_radius', precision=2):
+    def __init__(self, name='mad_radius', precision=2, conf_threshold=0.5):
         self.name = name
         self.precision = precision
+        self.conf_threshold = conf_threshold
 
-    def __call__(self, y_true, y_pred):
-        return mad_radius(y_true, y_pred)
+    def __call__(self, y_true, y_pred, conf_threshold=None):
+        if conf_threshold is None:
+            conf_threshold = self.conf_threshold
+        y_pred_temp = [
+            [(x, y, r) for (x, y, r, p) in y_pred_patch if p > conf_threshold]
+            for y_pred_patch in y_pred]
+        return mad_radius(y_true, y_pred_temp)


### PR DESCRIPTION
The approach I took now is for the the scores that only makes sense at a specific conf level, to have a default cut-off of 0.5.

This should at least make sure that submissions are required to return 4-length tuples (row, col, radius, conf), and ramp_test_submission runs.